### PR TITLE
Refactor/multiworld render

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Editor/LevelEditor/SLevelEditor.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/LevelEditor/SLevelEditor.cpp
@@ -481,6 +481,10 @@ FEditorViewportClient* SLevelEditor::AddWindowViewportClient(FName ViewportName,
 
     std::shared_ptr<FEditorViewportClient> NewViewportClient = std::make_shared<FEditorViewportClient>();
     NewViewportClient->Initialize(EViewScreenLocation::EVL_Window, InRect, PreviewWorld);
+
+    WindowViewportClients.Add(ViewportName, NewViewportClient);
+
+    return NewViewportClient.get();
 }
 
 void SLevelEditor::RemoveWindowViewportClient(FName ViewportName)

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/LevelEditor/SLevelEditor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/LevelEditor/SLevelEditor.h
@@ -4,6 +4,7 @@
 
 class SSplitterH;
 class SSplitterV;
+class UEngine;
 class FEditorViewportClient;
 
 
@@ -12,7 +13,7 @@ class SLevelEditor
 public:
     SLevelEditor();
 
-    void Initialize(uint32 InEditorWidth, uint32 InEditorHeight);
+    void Initialize(uint32 InEditorWidth, uint32 InEditorHeight, UEngine* EditorEngine);
     void Tick(float DeltaTime);
     void Release();
 
@@ -23,12 +24,20 @@ public:
     void SetEnableMultiViewport(bool bIsEnable);
     bool IsMultiViewport() const;
 
+    // AdditionalViewports에 추가적인 뷰포트를 추가
+    FEditorViewportClient* AddWindowViewportClient(FName ViewportName, UWorld* PreviewWorld, const FRect& InRect);
+    void RemoveWindowViewportClient(FName ViewportName);
+
+private:
+    void OnWorldChanged(UWorld* PIEWorld);
+
 private:
     SSplitterH* HSplitter;
     SSplitterV* VSplitter;
     
     std::shared_ptr<FEditorViewportClient> ViewportClients[4];
     std::shared_ptr<FEditorViewportClient> ActiveViewportClient;
+    TMap<FName, std::shared_ptr<FEditorViewportClient>> WindowViewportClients;
 
     /** 우클릭 시 캡처된 마우스 커서의 초기 위치 (스크린 좌표계) */
     FVector2D MousePinPosition;

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/LevelEditor/SLevelEditor.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/LevelEditor/SLevelEditor.h
@@ -64,6 +64,10 @@ public:
     {
         ActiveViewportClient = ViewportClients[Index];
     }
+    const TMap<FName, std::shared_ptr<FEditorViewportClient>>& GetWindowViewportClients() const
+    {
+        return WindowViewportClients;
+    }
 
 public:
     void LoadConfig();

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/EditorViewportClient.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/EditorViewportClient.cpp
@@ -23,7 +23,7 @@ FEditorViewportClient::FEditorViewportClient() : FViewportClient()
 {
 }
 
-void FEditorViewportClient::Initialize(EViewScreenLocation InViewportIndex, const FRect& InRect)
+void FEditorViewportClient::Initialize(EViewScreenLocation InViewportIndex, const FRect& InRect, UWorld* InWorld)
 {
     ViewportIndex = static_cast<uint32>(InViewportIndex);
     
@@ -35,6 +35,8 @@ void FEditorViewportClient::Initialize(EViewScreenLocation InViewportIndex, cons
 
     GizmoActor = FObjectFactory::ConstructObject<ATransformGizmo>(GEngine); // TODO : EditorEngine 외의 다른 Engine 형태가 추가되면 GEngine 대신 다른 방식으로 넣어주어야 함.
     GizmoActor->Initialize(this);
+
+    World = InWorld;
 }
 
 void FEditorViewportClient::Tick(const float DeltaTime)

--- a/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/EditorViewportClient.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Editor/UnrealEd/EditorViewportClient.h
@@ -9,6 +9,7 @@
 
 class ATransformGizmo;
 class USceneComponent;
+class UWorld;
 enum class EViewScreenLocation : uint8;
 
 class FEditorViewportClient : public FViewportClient
@@ -16,7 +17,7 @@ class FEditorViewportClient : public FViewportClient
 public:
     FEditorViewportClient();
     virtual void Tick(float DeltaTime) override;
-    void Initialize(EViewScreenLocation InViewportIndex, const FRect& InRect);
+    void Initialize(EViewScreenLocation InViewportIndex, const FRect& InRect, UWorld* InWorld);
 
     void UpdateEditorCameraMovement(float DeltaTime);
     void InputKey(const FKeyEvent& InKeyEvent);

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/EditorEngine.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/EditorEngine.cpp
@@ -199,6 +199,7 @@ void UEditorEngine::StartPIE()
 
     
 
+    OnStartPIE.Broadcast(PIEWorld);
     // 나중에 제거하기
 }
 
@@ -222,6 +223,8 @@ void UEditorEngine::EndPIE()
     }
     // 다시 EditorWorld로 돌아옴.
     ActiveWorld = EditorWorld;
+
+    OnEndPIE.Broadcast(ActiveWorld);
 }
 
 FWorldContext& UEditorEngine::GetEditorWorldContext(/*bool bEnsureIsGWorld*/)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/EditorEngine.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/Classes/Engine/EditorEngine.h
@@ -11,6 +11,9 @@
 class AActor;
 class USceneComponent;
 
+DECLARE_MULTICAST_DELEGATE_OneParam(OnStartPIEDelegate, UWorld*)
+DECLARE_MULTICAST_DELEGATE_OneParam(OnEndPIEDelegate, UWorld*)
+
 class UEditorEngine : public UEngine
 {
     DECLARE_CLASS(UEditorEngine, UEngine)
@@ -63,6 +66,10 @@ public:
     USceneComponent* GetSelectedComponent() const;
 
     void HoverComponent(USceneComponent* InComponent);
+
+public:
+    OnStartPIEDelegate OnStartPIE;
+    OnEndPIEDelegate OnEndPIE;
 
 public:
     UEditorPlayer* GetEditorPlayer() const;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UnrealClient.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UnrealClient.cpp
@@ -357,6 +357,8 @@ void FViewport::ResizeViewport(const FRect& Top, const FRect& Bottom, const FRec
         Rect.Width = Right.Width;
         Rect.Height = Bottom.Height;
         break;
+    case EViewScreenLocation::EVL_Window:
+        // NOTE : 개별 Window로 렌더링되는 뷰포트의 경우, 여기서 사이즈 조절 하지 않는다
     default:
         return;
     }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UnrealClient.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/UnrealClient.h
@@ -12,6 +12,7 @@ enum class EViewScreenLocation : uint8
     EVL_TopRight,
     EVL_BottomLeft,
     EVL_BottomRight,
+    EVL_Window,
     EVL_MAX,
 };
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ViewportClient.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Engine/ViewportClient.h
@@ -95,6 +95,8 @@ public:
     uint32 GetViewportIndex() const { return ViewportIndex; }
     D3D11_VIEWPORT& GetD3DViewport() const;
     FViewportResource* GetViewportResource();
+    void SetWorld(UWorld* InWorld) { World = InWorld; }
+    UWorld* GetWorld() const { return World; }
 
 protected:
     FViewport* Viewport = nullptr;
@@ -116,6 +118,10 @@ protected:
     ELevelViewportType ViewportType;
     uint64 ShowFlag;
     EViewModeIndex ViewMode;
+
+protected:
+    // 참조중인 월드 정보
+    UWorld* World = nullptr;
 
     
     // 카메라 정보

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
@@ -129,6 +129,12 @@ void FEngineLoop::Render() const
         Renderer.RenderViewport(ActiveViewportCache);
     }
     
+    auto& WindowViewportClients = LevelEditor->GetWindowViewportClients();
+    for (auto& WindowViewport : WindowViewportClients)
+    {
+        Renderer.Render(WindowViewport.Value);
+        Renderer.RenderViewport(WindowViewport.Value);
+    }
 }
 
 void FEngineLoop::Tick()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Launch/EngineLoop.cpp
@@ -90,10 +90,11 @@ int32 FEngineLoop::Init(HINSTANCE hInstance)
     uint32 ClientWidth = 0;
     uint32 ClientHeight = 0;
     GetClientSize(ClientWidth, ClientHeight);
-    LevelEditor->Initialize(ClientWidth, ClientHeight);
 
+    // !TODO : WITH_EDITOR등의 전처리기로 감싸기
     GEngine = FObjectFactory::ConstructObject<UEditorEngine>(nullptr);
     GEngine->Init();
+    LevelEditor->Initialize(ClientWidth, ClientHeight, GEngine);
 
     LastWarGameUI->Initialize();
     UpdateUI();

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.cpp
@@ -42,7 +42,7 @@ void FBillboardRenderPass::Initialize(FDXDBufferManager* InBufferManager, FGraph
     CreateShader();
 }
 
-void FBillboardRenderPass::PrepareRenderArr()
+void FBillboardRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
     BillboardComps.Empty();
     for (const auto iter : TObjectRange<UBillboardComponent>())

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/BillboardRenderPass.h
@@ -21,7 +21,7 @@ public:
 
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManage) override;
 
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
     void UpdateObjectConstant(const FMatrix& WorldMatrix, const FVector4& UUIDColor, bool bIsSelected) const;
 
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/CompositingPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/CompositingPass.cpp
@@ -42,7 +42,7 @@ void FCompositingPass::Initialize(FDXDBufferManager* InBufferManager, FGraphicsD
     ViewModeBuffer = BufferManager->GetConstantBuffer("FViewModeConstants");
 }
 
-void FCompositingPass::PrepareRenderArr()
+void FCompositingPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/CompositingPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/CompositingPass.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include <memory>
 
 #include "IRenderPass.h"
@@ -12,7 +12,7 @@ public:
     
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManage) override;
     
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
 
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/DepthPrePass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/DepthPrePass.cpp
@@ -22,9 +22,9 @@ void FDepthPrePass::Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevi
     __super::Initialize(InBufferManager, InGraphics, InShaderManage);
 }
 
-void FDepthPrePass::PrepareRenderArr()
+void FDepthPrePass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
-    __super::PrepareRenderArr();
+    __super::PrepareRenderArr(Viewport);
 }
 
 void FDepthPrePass::Render(const std::shared_ptr<FViewportClient>& Viewport)

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/DepthPrePass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/DepthPrePass.h
@@ -12,7 +12,7 @@ public:
     ~FDepthPrePass();
     
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManage) override;
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
     virtual void ClearRenderArr() override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorBillboardRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorBillboardRenderPass.cpp
@@ -5,18 +5,22 @@
 #include "Engine/Engine.h"
 #include "UObject/UObjectIterator.h"
 #include "Components/BillboardComponent.h"
+#include "Engine/ViewportClient.h"
 
 FEditorBillboardRenderPass::FEditorBillboardRenderPass()
 {
     ResourceType = EResourceType::ERT_Editor;
 }
 
-void FEditorBillboardRenderPass::PrepareRenderArr()
+void FEditorBillboardRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
+    if (Viewport == nullptr || Viewport->GetWorld() == nullptr)
+        return;
+
     BillboardComps.Empty();
     for (const auto Component : TObjectRange<UBillboardComponent>())
     {
-        if (Component->GetWorld() == GEngine->ActiveWorld && Component->bIsEditorBillboard)
+        if (Component->GetWorld() == Viewport->GetWorld() && Component->bIsEditorBillboard)
         {
             BillboardComps.Add(Component);
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorBillboardRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorBillboardRenderPass.h
@@ -8,5 +8,5 @@ public:
     FEditorBillboardRenderPass();
     virtual ~FEditorBillboardRenderPass() = default;
 
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorRenderPass.cpp
@@ -388,17 +388,20 @@ void FEditorRenderPass::BindBuffers(const FDebugPrimitiveData& InPrimitiveData) 
     Graphics->DeviceContext->IASetIndexBuffer(InPrimitiveData.IndexInfo.IndexBuffer, DXGI_FORMAT_R32_UINT, 0);
 }
 
-void FEditorRenderPass::PrepareRenderArr()
+void FEditorRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
     if (GEngine->ActiveWorld->WorldType != EWorldType::Editor)
     {
         return;
     }
+
+    if (Viewport == nullptr || Viewport->GetWorld() == nullptr)
+        return;
     
     // gizmo 제외하고 넣기
     for (const auto* Actor : TObjectRange<AActor>())
     {
-        if (!Actor->IsActorBeingDestroyed() && Actor->GetWorld() != GEngine->ActiveWorld)
+        if (!Actor->IsActorBeingDestroyed() && Actor->GetWorld() != Viewport->GetWorld())
         {
             continue;
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/EditorRenderPass.h
@@ -15,7 +15,7 @@ class FEditorRenderPass : public IRenderPass
 public:
     void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManager) override;
     void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
-    void PrepareRenderArr() override;
+    void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
     void ClearRenderArr() override;
 
 private:

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FadeRenderpass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FadeRenderpass.cpp
@@ -76,11 +76,16 @@ void FFadeRenderPass::ReleaseShader()
 
 }
 
-void FFadeRenderPass::PrepareRenderArr()
+void FFadeRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
-    if (GEngine->ActiveWorld && GEngine->ActiveWorld->WorldType != EWorldType::Editor) {
-        FadeAlpha = GEngine->ActiveWorld->GetFirstPlayerController()->PlayerCameraManager->FadeAmount;
-        FadeColor = GEngine->ActiveWorld->GetFirstPlayerController()->PlayerCameraManager->FadeColor;
+    if (Viewport == nullptr || Viewport->GetWorld() == nullptr)
+        return;
+
+    UWorld* World = Viewport->GetWorld();
+
+    if (World && World->WorldType != EWorldType::Editor) {
+        FadeAlpha = World->GetFirstPlayerController()->PlayerCameraManager->FadeAmount;
+        FadeColor = World->GetFirstPlayerController()->PlayerCameraManager->FadeColor;
     }
     else
     {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FadeRenderpass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FadeRenderpass.h
@@ -19,7 +19,7 @@ public:
 
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManage) override;
 
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
 
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.cpp
@@ -62,11 +62,14 @@ void FFogRenderPass::ReleaseShader()
 {
 }
 
-void FFogRenderPass::PrepareRenderArr()
+void FFogRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
+    if (Viewport == nullptr || Viewport->GetWorld() == nullptr)
+        return;
+
     for (const auto iter : TObjectRange<UHeightFogComponent>())
     {
-        if (iter->GetWorld() == GEngine->ActiveWorld)
+        if (iter->GetWorld() == Viewport->GetWorld())
         {
             FogComponents.Add(iter);
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/FogRenderPass.h
@@ -19,7 +19,7 @@ public:
 
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManage) override;
     
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
 
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.cpp
@@ -111,7 +111,7 @@ void FGizmoRenderPass::PrepareRenderState() const
     Graphics->DeviceContext->PSSetSamplers(0, 1, &Sampler);
 }
 
-void FGizmoRenderPass::PrepareRenderArr()
+void FGizmoRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/GizmoRenderPass.h
@@ -18,7 +18,7 @@ public:
 
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManage) override;
 
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
 
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/IRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/IRenderPass.h
@@ -14,7 +14,7 @@ public:
     
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManage) = 0;
 
-    virtual void PrepareRenderArr() = 0;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) = 0;
     
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) = 0;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.cpp
@@ -39,7 +39,7 @@ void FLineRenderPass::Initialize(FDXDBufferManager* InBufferManager, FGraphicsDe
     CreateShader();
 }
 
-void FLineRenderPass::PrepareRenderArr()
+void FLineRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/LineRenderPass.h
@@ -18,7 +18,7 @@ public:
     ~FLineRenderPass();
 
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManager) override;
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
     virtual void ClearRenderArr() override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/PostProcessCompositingPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/PostProcessCompositingPass.cpp
@@ -41,7 +41,7 @@ void FPostProcessCompositingPass::Initialize(FDXDBufferManager* InBufferManager,
     Graphics->Device->CreateSamplerState(&SamplerDesc, &Sampler);
 }
 
-void FPostProcessCompositingPass::PrepareRenderArr()
+void FPostProcessCompositingPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/PostProcessCompositingPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/PostProcessCompositingPass.h
@@ -10,7 +10,7 @@ public:
     
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManage) override;
     
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
 
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/Renderer.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/Renderer.cpp
@@ -226,22 +226,21 @@ void FRenderer::PrepareRender(FViewportResource* ViewportResource) const
     ViewportResource->ClearDepthStencils(Graphics->DeviceContext);
     ViewportResource->ClearRenderTargets(Graphics->DeviceContext);
 
-    PrepareRenderPass();
 }
 
-void FRenderer::PrepareRenderPass() const
+void FRenderer::PrepareRenderPass(const std::shared_ptr<FViewportClient>& Viewport) const
 {
-    StaticMeshRenderPass->PrepareRenderArr();
-    ShadowRenderPass->PrepareRenderArr();
-    GizmoRenderPass->PrepareRenderArr();
-    WorldBillboardRenderPass->PrepareRenderArr();
-    EditorBillboardRenderPass->PrepareRenderArr();
-    UpdateLightBufferPass->PrepareRenderArr();
-    FogRenderPass->PrepareRenderArr();
-    EditorRenderPass->PrepareRenderArr();
-    TileLightCullingPass->PrepareRenderArr();
-    DepthPrePass->PrepareRenderArr();
-    FadeRenderPass->PrepareRenderArr();
+    StaticMeshRenderPass->PrepareRenderArr(Viewport);
+    ShadowRenderPass->PrepareRenderArr(Viewport);
+    GizmoRenderPass->PrepareRenderArr(Viewport);
+    WorldBillboardRenderPass->PrepareRenderArr(Viewport);
+    EditorBillboardRenderPass->PrepareRenderArr(Viewport);
+    UpdateLightBufferPass->PrepareRenderArr(Viewport);
+    FogRenderPass->PrepareRenderArr(Viewport);
+    EditorRenderPass->PrepareRenderArr(Viewport);
+    TileLightCullingPass->PrepareRenderArr(Viewport);
+    DepthPrePass->PrepareRenderArr(Viewport);
+    FadeRenderPass->PrepareRenderArr(Viewport);
 }
 
 void FRenderer::ClearRenderArr() const
@@ -327,6 +326,8 @@ void FRenderer::BeginRender(const std::shared_ptr<FViewportClient>& Viewport)
     UpdateCommonBuffer(Viewport);
     
     PrepareRender(ViewportResource);
+
+    PrepareRenderPass(Viewport);
 }
 
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/Renderer.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/Renderer.h
@@ -64,7 +64,7 @@ protected:
     void BeginRender(const std::shared_ptr<FViewportClient>& Viewport);
     void UpdateCommonBuffer(const std::shared_ptr<FViewportClient>& Viewport) const;
     void PrepareRender(FViewportResource* ViewportResource) const;
-    void PrepareRenderPass() const;
+    void PrepareRenderPass(const std::shared_ptr<FViewportClient>& Viewport) const;
     void RenderWorldScene(const std::shared_ptr<FViewportClient>& Viewport) const;
     void RenderPostProcess(const std::shared_ptr<FViewportClient>& Viewport) const;
     void RenderEditorOverlay(const std::shared_ptr<FViewportClient>& Viewport) const;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/ShadowRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/ShadowRenderPass.cpp
@@ -84,11 +84,14 @@ void FShadowRenderPass::PrepareCSMRenderState()
 
 }
 
-void FShadowRenderPass::PrepareRenderArr()
+void FShadowRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
+    if (Viewport == nullptr || Viewport->GetWorld() == nullptr)
+        return;
+
     for (const auto iter : TObjectRange<UStaticMeshComponent>())
     {
-        if (!Cast<UGizmoBaseComponent>(iter) && iter->GetWorld() == GEngine->ActiveWorld)
+        if (!Cast<UGizmoBaseComponent>(iter) && iter->GetWorld() == Viewport->GetWorld())
         {
             StaticMeshComponents.Add(iter);
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/ShadowRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/ShadowRenderPass.h
@@ -32,7 +32,7 @@ public:
     void InitializeShadowManager(class FShadowManager* InShadowManager);
     void PrepareRenderState();
     void PrepareCSMRenderState();
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
     void UpdateIsShadowConstant(int32 isShadow) const;
     void Render(ULightComponentBase* Light);
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;    

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SlateRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SlateRenderPass.cpp
@@ -1,4 +1,4 @@
-﻿#include "SlateRenderPass.h"
+#include "SlateRenderPass.h"
 
 #include "RendererHelpers.h"
 #include "UnrealClient.h"
@@ -29,7 +29,7 @@ void FSlateRenderPass::Initialize(FDXDBufferManager* InBufferManager, FGraphicsD
     CreateSampler();
 }
 
-void FSlateRenderPass::PrepareRenderArr()
+void FSlateRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
 }
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SlateRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SlateRenderPass.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "IRenderPass.h"
 
 #include "Define.h"
@@ -17,7 +17,7 @@ public:
 
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManager) override;
     
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
 
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.cpp
@@ -166,11 +166,14 @@ void FStaticMeshRenderPass::InitializeShadowManager(class FShadowManager* InShad
     ShadowManager = InShadowManager;
 }
 
-void FStaticMeshRenderPass::PrepareRenderArr()
+void FStaticMeshRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
+    if (Viewport == nullptr || Viewport->GetWorld() == nullptr)
+        return;
+
     for (const auto iter : TObjectRange<UStaticMeshComponent>())
     {
-        if (!Cast<UGizmoBaseComponent>(iter) && iter->GetWorld() == GEngine->ActiveWorld)
+        if (!Cast<UGizmoBaseComponent>(iter) && iter->GetWorld() == Viewport->GetWorld())
         {
             StaticMeshComponents.Add(iter);
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.h
@@ -24,7 +24,7 @@ public:
     
     void InitializeShadowManager(class FShadowManager* InShadowManager);
     
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
 
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/TileLightCullingPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/TileLightCullingPass.cpp
@@ -47,11 +47,14 @@ void FTileLightCullingPass::Initialize(FDXDBufferManager* InBufferManager, FGrap
     CreateBuffers(Graphics->ScreenWidth, Graphics->ScreenHeight); // 시작은 전체 크기
 }
 
-void FTileLightCullingPass::PrepareRenderArr()
+void FTileLightCullingPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
+    if (Viewport == nullptr || Viewport->GetWorld() == nullptr)
+        return;
+
     for (const auto iter : TObjectRange<ULightComponentBase>())
     {
-        if (iter->GetWorld() == GEngine->ActiveWorld)
+        if (iter->GetWorld() == Viewport->GetWorld())
         {
             if (UPointLightComponent* PointLight = Cast<UPointLightComponent>(iter))
             {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/TileLightCullingPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/TileLightCullingPass.h
@@ -50,7 +50,7 @@ public:
     ~FTileLightCullingPass();
     void ResizeTiles(UINT InWidth, UINT InHeight);
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManage) override;
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
     virtual void ClearRenderArr() override;
 

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.cpp
@@ -15,6 +15,7 @@
 #include "GameFramework/Actor.h"
 #include "UObject/UObjectIterator.h"
 #include "TileLightCullingPass.h"
+#include "Engine/ViewportClient.h"
 
 //------------------------------------------------------------------------------
 // 생성자/소멸자
@@ -42,11 +43,14 @@ void FUpdateLightBufferPass::Initialize(FDXDBufferManager* InBufferManager, FGra
     CreateSpotLightPerTilesBuffer();
 }
 
-void FUpdateLightBufferPass::PrepareRenderArr()
+void FUpdateLightBufferPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
+    if (Viewport == nullptr || Viewport->GetWorld() == nullptr)
+        return;
+
     for (const auto iter : TObjectRange<ULightComponentBase>())
     {
-        if (iter->GetWorld() == GEngine->ActiveWorld)
+        if (iter->GetWorld() == Viewport->GetWorld())
         {
             if (UPointLightComponent* PointLight = Cast<UPointLightComponent>(iter))
             {

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/UpdateLightBufferPass.h
@@ -33,7 +33,7 @@ public:
     virtual ~FUpdateLightBufferPass();
 
     virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManager) override;
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
     virtual void Render(const std::shared_ptr<FViewportClient>& Viewport) override;
     virtual void ClearRenderArr() override;
     void UpdateLightBuffer() const;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/WorldBillboardRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/WorldBillboardRenderPass.cpp
@@ -5,18 +5,22 @@
 #include "Engine/Engine.h"
 #include "UObject/UObjectIterator.h"
 #include "Components/BillboardComponent.h"
+#include "Engine/ViewportClient.h"
 
 FWorldBillboardRenderPass::FWorldBillboardRenderPass()
 {
     ResourceType = EResourceType::ERT_Scene;
 }
 
-void FWorldBillboardRenderPass::PrepareRenderArr()
+void FWorldBillboardRenderPass::PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport)
 {
+    if (Viewport == nullptr || Viewport->GetWorld() == nullptr)
+        return;
+
     BillboardComps.Empty();
     for (const auto Component : TObjectRange<UBillboardComponent>())
     {
-        if (Component->GetWorld() == GEngine->ActiveWorld && !Component->bIsEditorBillboard)
+        if (Component->GetWorld() == Viewport->GetWorld() && !Component->bIsEditorBillboard)
         {
             BillboardComps.Add(Component);
         }

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/WorldBillboardRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/WorldBillboardRenderPass.h
@@ -8,5 +8,5 @@ public:
     FWorldBillboardRenderPass();
     virtual ~FWorldBillboardRenderPass() = default;
 
-    virtual void PrepareRenderArr() override;
+    virtual void PrepareRenderArr(const std::shared_ptr<FViewportClient>& Viewport) override;
 };


### PR DESCRIPTION
- ViewportClient가 World의 참조를 가지도록 수정
- RenderPass에서 ViewportClient가 참조하고 있는 월드 포인터를 바탕으로 RenderArr를 구성하도록 수정
- World가 변경되었을 때(PIE 진입 및 퇴장) 델리게이트 추가하여 뷰포트들 월드포인터 변경
- PreviewWindow용 ViewportClient를 추가 및 제거할 수 있도록 API 추가